### PR TITLE
🐛 Fix store initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13509,6 +13509,12 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==",
+      "dev": true
+    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "redux-devtools-extension": "^2.13.8"
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,8 @@
-import {createStore, applyMiddleware, compose} from 'redux';
-import thunk from 'redux-thunk';
+import {applyMiddleware, createStore} from 'redux';
+
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import rootReducer from './reducers';
+import thunk from 'redux-thunk';
 
 const initialState = {};
 
@@ -9,9 +11,8 @@ const middleware = [thunk];
 const store = createStore(
     rootReducer,
     initialState,
-    compose(
+    composeWithDevTools(
         applyMiddleware(...middleware),
-        window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
     )
 )
 


### PR DESCRIPTION
Fix the `Cannot read property 'apply' of undefined` error when creating the Redux store. Seems like this arises from passing an undefined value to the `compose` function. Found the fix at: https://github.com/reduxjs/redux/issues/2359#issuecomment-313821488